### PR TITLE
Fix missing DLLs in Windows 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,17 +270,16 @@ jobs:
         mv faiss\faiss\python\swigfaiss.swig faiss\faiss\python\swigfaiss.i
         New-Item -ItemType file faiss\contrib\__init__.py
         $Env:FAISS_INCLUDE = ""
-        $Env:FAISS_LDFLAGS = "faiss${env:FAISS_LIBRARY_SUFFIX}.lib openblas.lib libomp.lib"
+        $Env:FAISS_LDFLAGS = "faiss${env:FAISS_LIBRARY_SUFFIX}.lib openblas.lib"
 
         cp "${env:CONDA_PREFIX}\Library\bin\flang.dll" faiss\faiss\python
         cp "${env:CONDA_PREFIX}\Library\bin\flangrti.dll" faiss\faiss\python
-        cp "${env:CONDA_PREFIX}\Library\bin\libomp.dll" faiss\faiss\python
         cp "${env:CONDA_PREFIX}\Library\bin\openblas.dll" faiss\faiss\python
 
         pip install --no-cache-dir -U pip
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w dist --no-deps --verbose
-        delvewheel show (Get-Item .\dist\faiss*.whl)
+        delvewheel show (Get-Item .\dist\faiss*.whl) --ignore-in-wheel
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,15 +270,13 @@ jobs:
         mv faiss\faiss\python\swigfaiss.swig faiss\faiss\python\swigfaiss.i
         New-Item -ItemType file faiss\contrib\__init__.py
         $Env:FAISS_INCLUDE = ""
-        $Env:FAISS_LDFLAGS = "faiss${env:FAISS_LIBRARY_SUFFIX}.lib openblas.lib"
+        $Env:FAISS_LDFLAGS = "faiss${env:FAISS_LIBRARY_SUFFIX}.lib openblas.lib libomp.lib"
 
         pip install --no-cache-dir -U pip
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w wheelhouse --no-deps --verbose
-        delvewheel show (Get-Item .\wheelhouse\faiss*.whl) `
-          --no-dll "concrt140.dll;msvcp140.dll;vcomp140.dll;vcruntime140_1.dll"
-        delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl) `
-          --no-dll "concrt140.dll;msvcp140.dll;vcomp140.dll;vcruntime140_1.dll"
+        delvewheel show (Get-Item .\wheelhouse\faiss*.whl)
+        delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl)
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,6 +306,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: wheel-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.opt }}
+        path: dist
     - name: Install and test
       if: matrix.python-version != 3.9
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,11 +272,15 @@ jobs:
         $Env:FAISS_INCLUDE = ""
         $Env:FAISS_LDFLAGS = "faiss${env:FAISS_LIBRARY_SUFFIX}.lib openblas.lib libomp.lib"
 
+        cp "{env:CONDA_PREFIX}\Library\bin\flang.dll" faiss\faiss\python
+        cp "{env:CONDA_PREFIX}\Library\bin\flangrti.dll" faiss\faiss\python
+        cp "{env:CONDA_PREFIX}\Library\bin\libomp.dll" faiss\faiss\python
+        cp "{env:CONDA_PREFIX}\Library\bin\openblas.dll" faiss\faiss\python
+
         pip install --no-cache-dir -U pip
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
-        pip wheel . -w wheelhouse --no-deps --verbose
-        delvewheel show (Get-Item .\wheelhouse\faiss*.whl)
-        delvewheel repair -w dist -L . (Get-Item .\wheelhouse\faiss*.whl)
+        pip wheel . -w dist --no-deps --verbose
+        delvewheel show (Get-Item .\dist\faiss*.whl)
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,7 +276,7 @@ jobs:
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w wheelhouse --no-deps --verbose
         delvewheel show (Get-Item .\wheelhouse\faiss*.whl) `
-          --add-path "${env:CONDA_PREFIX}\Library\lib" `
+          --add-path "${env:CONDA_PREFIX}\Library\lib"
         delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl) `
           --add-path "${env:CONDA_PREFIX}\Library\lib" `
           --add-dll flang.dll;flangrti.dll;libomp.dll `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,9 +276,9 @@ jobs:
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w wheelhouse --no-deps --verbose
         delvewheel show (Get-Item .\wheelhouse\faiss*.whl) `
-          --add-dll openblas.dll;flang.dll;flangrti.dll;libomp.dll
+          --add-dll openblas;flang;flangrti;libomp
         delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl) `
-          --add-dll openblas.dll;flang.dll;flangrti.dll;libomp.dll
+          --add-dll openblas;flang;flangrti;libomp
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,14 +268,19 @@ jobs:
         $Env:FAISS_INCLUDE = ""
         $Env:FAISS_LDFLAGS = "faiss${env:FAISS_LIBRARY_SUFFIX}.lib openblas.lib"
 
-        cp "${env:CONDA_PREFIX}\Library\bin\flang.dll" faiss\faiss\python
-        cp "${env:CONDA_PREFIX}\Library\bin\flangrti.dll" faiss\faiss\python
-        cp "${env:CONDA_PREFIX}\Library\bin\openblas.dll" faiss\faiss\python
+        # cp "${env:CONDA_PREFIX}\Library\bin\flang.dll" faiss\faiss\python
+        # cp "${env:CONDA_PREFIX}\Library\bin\flangrti.dll" faiss\faiss\python
+        # cp "${env:CONDA_PREFIX}\Library\bin\openblas.dll" faiss\faiss\python
+        # cp "${env:CONDA_PREFIX}\Library\bin\libomp.dll" faiss\faiss\python
+        # cp "${env:CONDA_PREFIX}\Library\bin\concrt140.dll" faiss\faiss\python
+        # cp "${env:CONDA_PREFIX}\Library\bin\msvcp140.dll" faiss\faiss\python
+        # cp "${env:CONDA_PREFIX}\Library\bin\vcomp140.dll" faiss\faiss\python
 
         pip install --no-cache-dir -U pip
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w dist --no-deps --verbose
         delvewheel show (Get-Item .\dist\faiss*.whl) --ignore-in-wheel
+        delvewheel repair (Get-Item .\dist\faiss*.whl) --ignore-in-wheel
         Get-ChildItem -Path dist
     - name: Upload package for test
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ on:
   release:
     types: [created]
 env:
-  SWIG_VERSION: '4.0.2'
   NUMPY_VERSION: '1.18.0'
   FAISS_OPT_LEVEL: generic
   FAISS_LIBRARY_SUFFIX: ''
@@ -33,6 +32,7 @@ jobs:
         opt:
           - 'generic'
     env:
+      SWIG_VERSION: '4.0.2'
       FAISS_ENABLE_GPU: 'OFF'
       CUDA_VERSION: '10.0'
       CUDA_PKG_VERSION: 10-0-10.0.130-1
@@ -261,10 +261,6 @@ jobs:
         cmake --build build --config Release -j -v
         cmake --install build --prefix ${env:CMAKE_PREFIX_PATH} -v
         cd ..
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Build package
       run: |
         mv faiss\faiss\python\swigfaiss.swig faiss\faiss\python\swigfaiss.i
@@ -281,9 +277,38 @@ jobs:
         pip wheel . -w dist --no-deps --verbose
         delvewheel show (Get-Item .\dist\faiss*.whl) --ignore-in-wheel
         Get-ChildItem -Path dist
+    - name: Upload package for test
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheel-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.opt }}
+        path: dist
+  test-win:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+        opt:
+          - 'generic'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Download package for test
+      uses: actions/download-artifact@v2
+      with:
+        name: wheel-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.opt }}
     - name: Install and test
       if: matrix.python-version != 3.9
       run: |
+        pip install --no-cache-dir -U pip
         pip install --no-cache-dir (Get-Item .\dist\faiss*.whl)
         pip install --no-cache-dir pytest scipy
         pytest `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,7 +280,7 @@ jobs:
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w dist --no-deps --verbose
         delvewheel show (Get-Item .\dist\faiss*.whl) --ignore-in-wheel
-        delvewheel repair (Get-Item .\dist\faiss*.whl) --ignore-in-wheel
+        delvewheel repair -w dist (Get-Item .\dist\faiss*.whl) --ignore-in-wheel
         Get-ChildItem -Path dist
     - name: Upload package for test
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,9 +276,9 @@ jobs:
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w wheelhouse --no-deps --verbose
         delvewheel show (Get-Item .\wheelhouse\faiss*.whl) `
-          --add-dll openblas;flang;flangrti;libomp
+          --add-dll "openblas;flang;flangrti;libomp"
         delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl) `
-          --add-dll openblas;flang;flangrti;libomp
+          --add-dll "openblas;flang;flangrti;libomp"
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,6 +283,7 @@ jobs:
         name: wheel-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.opt }}
         path: dist
   test-win:
+    needs: build-win
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,10 +276,9 @@ jobs:
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w wheelhouse --no-deps --verbose
         delvewheel show (Get-Item .\wheelhouse\faiss*.whl) `
-          --add-path "${env:CONDA_PREFIX}\Library\lib"
+          --add-dll openblas.dll;flang.dll;flangrti.dll;libomp.dll
         delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl) `
-          --add-path "${env:CONDA_PREFIX}\Library\lib" `
-          --no-dll concrt140.dll;msvcp140.dll;vcomp140.dll
+          --add-dll openblas.dll;flang.dll;flangrti.dll;libomp.dll
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,7 @@ jobs:
         delocate-wheel -v dist/faiss*.whl
         ls -lh dist
     - name: Install and test
-      if: matrix.python-version != 3.9 && matrix.opt != 'avx2'
+      if: matrix.opt != 'avx2'
       run: |
         pip install --no-cache-dir dist/faiss*.whl
         pip install --no-cache-dir pytest scipy
@@ -218,15 +218,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Set up build environment
-      run: |
-        $installationPath = vswhere.exe -prerelease -latest -property installationPath
-        if ($installationPath -and (test-path "$installationPath\Common7\Tools\vsdevcmd.bat")) {
-          & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -arch=x64 -no_logo && set" | foreach-object {
-            $name, $value = $_ -split '=', 2
-            echo "$name=$value" >> ${env:GITHUB_ENV}
-          }
-        }
+    - uses: ilammy/msvc-dev-cmd@v1
     - name: Set optimization level
       if: matrix.opt != 'generic'
       run: |
@@ -268,19 +260,11 @@ jobs:
         $Env:FAISS_INCLUDE = ""
         $Env:FAISS_LDFLAGS = "faiss${env:FAISS_LIBRARY_SUFFIX}.lib openblas.lib"
 
-        # cp "${env:CONDA_PREFIX}\Library\bin\flang.dll" faiss\faiss\python
-        # cp "${env:CONDA_PREFIX}\Library\bin\flangrti.dll" faiss\faiss\python
-        # cp "${env:CONDA_PREFIX}\Library\bin\openblas.dll" faiss\faiss\python
-        # cp "${env:CONDA_PREFIX}\Library\bin\libomp.dll" faiss\faiss\python
-        # cp "${env:CONDA_PREFIX}\Library\bin\concrt140.dll" faiss\faiss\python
-        # cp "${env:CONDA_PREFIX}\Library\bin\msvcp140.dll" faiss\faiss\python
-        # cp "${env:CONDA_PREFIX}\Library\bin\vcomp140.dll" faiss\faiss\python
-
         pip install --no-cache-dir -U pip
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w dist --no-deps --verbose
-        delvewheel show (Get-Item .\dist\faiss*.whl) --ignore-in-wheel
-        delvewheel repair -w dist (Get-Item .\dist\faiss*.whl) --ignore-in-wheel
+        delvewheel show (Get-Item .\dist\faiss*.whl)
+        delvewheel repair -w dist (Get-Item .\dist\faiss*.whl)
         Get-ChildItem -Path dist
     - name: Upload package for test
       uses: actions/upload-artifact@v2
@@ -313,7 +297,6 @@ jobs:
         name: wheel-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.opt }}
         path: dist
     - name: Install and test
-      if: matrix.python-version != 3.9
       run: |
         pip install --no-cache-dir -U pip
         pip install --no-cache-dir (Get-Item .\dist\faiss*.whl)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,7 +276,7 @@ jobs:
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w wheelhouse --no-deps --verbose
         delvewheel show (Get-Item .\wheelhouse\faiss*.whl)
-        delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl)
+        delvewheel repair -w dist -L . (Get-Item .\wheelhouse\faiss*.whl)
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,10 +272,10 @@ jobs:
         $Env:FAISS_INCLUDE = ""
         $Env:FAISS_LDFLAGS = "faiss${env:FAISS_LIBRARY_SUFFIX}.lib openblas.lib libomp.lib"
 
-        cp "{env:CONDA_PREFIX}\Library\bin\flang.dll" faiss\faiss\python
-        cp "{env:CONDA_PREFIX}\Library\bin\flangrti.dll" faiss\faiss\python
-        cp "{env:CONDA_PREFIX}\Library\bin\libomp.dll" faiss\faiss\python
-        cp "{env:CONDA_PREFIX}\Library\bin\openblas.dll" faiss\faiss\python
+        cp "${env:CONDA_PREFIX}\Library\bin\flang.dll" faiss\faiss\python
+        cp "${env:CONDA_PREFIX}\Library\bin\flangrti.dll" faiss\faiss\python
+        cp "${env:CONDA_PREFIX}\Library\bin\libomp.dll" faiss\faiss\python
+        cp "${env:CONDA_PREFIX}\Library\bin\openblas.dll" faiss\faiss\python
 
         pip install --no-cache-dir -U pip
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,9 +276,9 @@ jobs:
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w wheelhouse --no-deps --verbose
         delvewheel show (Get-Item .\wheelhouse\faiss*.whl) `
-          --add-dll "openblas;flang;flangrti;libomp"
+          --no-dll "concrt140;msvcp140;vcomp140"
         delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl) `
-          --add-dll "openblas;flang;flangrti;libomp"
+          --no-dll "concrt140;msvcp140;vcomp140"
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,9 +274,13 @@ jobs:
 
         pip install --no-cache-dir -U pip
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
-        pip wheel . -w dist --no-deps --verbose
-        delvewheel show (Get-Item .\dist\faiss*.whl) --add-path "${env:CONDA_PREFIX}\Library\lib"
-        delvewheel repair -w dist (Get-Item .\dist\faiss*.whl) --add-path "${env:CONDA_PREFIX}\Library\lib"
+        pip wheel . -w wheelhouse --no-deps --verbose
+        delvewheel show (Get-Item .\wheelhouse\faiss*.whl) `
+          --add-path "${env:CONDA_PREFIX}\Library\lib" `
+        delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl) `
+          --add-path "${env:CONDA_PREFIX}\Library\lib" `
+          --add-dll flang.dll;flangrti.dll;libomp.dll `
+          --no-dll openblas.dll
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,8 +279,7 @@ jobs:
           --add-path "${env:CONDA_PREFIX}\Library\lib"
         delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl) `
           --add-path "${env:CONDA_PREFIX}\Library\lib" `
-          --add-dll flang.dll;flangrti.dll;libomp.dll `
-          --no-dll openblas.dll
+          --no-dll concrt140.dll;msvcp140.dll;vcomp140.dll
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,7 +276,7 @@ jobs:
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w dist --no-deps --verbose
         delvewheel show (Get-Item .\dist\faiss*.whl) --add-path "${env:CONDA_PREFIX}\Library\lib"
-        delvewheel repair (Get-Item .\dist\faiss*.whl) --add-path "${env:CONDA_PREFIX}\Library\lib"
+        delvewheel repair -w dist (Get-Item .\dist\faiss*.whl) --add-path "${env:CONDA_PREFIX}\Library\lib"
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,9 +276,9 @@ jobs:
         pip install --no-cache-dir wheel numpy==${env:NUMPY_VERSION} delvewheel
         pip wheel . -w wheelhouse --no-deps --verbose
         delvewheel show (Get-Item .\wheelhouse\faiss*.whl) `
-          --no-dll "concrt140;msvcp140;vcomp140"
+          --no-dll "concrt140.dll;msvcp140.dll;vcomp140.dll;vcruntime140_1.dll"
         delvewheel repair -w dist (Get-Item .\wheelhouse\faiss*.whl) `
-          --no-dll "concrt140;msvcp140;vcomp140"
+          --no-dll "concrt140.dll;msvcp140.dll;vcomp140.dll;vcruntime140_1.dll"
         Get-ChildItem -Path dist
     - name: Install and test
       if: matrix.python-version != 3.9

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 
 .DS_Store
 *~
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ if sys.platform == 'win32':
             'openblas.lib',
         ]
     SWIG_OPTS += ['-DSWIGWIN']
+    PACKAGE_DATA += ['*.dll']
 elif sys.platform == 'linux':
     EXTRA_COMPILE_ARGS += [
         '-std=c++11',
@@ -99,7 +100,6 @@ elif sys.platform == 'linux':
             '-lgfortran',
         ]
     SWIG_OPTS += ['-DSWIGWORDSIZE64']
-    PACKAGE_DATA += ['*.dll']
 elif sys.platform == 'darwin':
     EXTRA_COMPILE_ARGS += [
         '-std=c++11',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 import os
 
 NAME = 'faiss-cpu'
-VERSION = '1.7.1.post1'
+VERSION = '1.7.1.post2'
 
 LONG_DESCRIPTION = """
 Faiss is a library for efficient similarity search and clustering of dense
@@ -56,7 +56,6 @@ SWIG_OPTS = [
     '-I' + FAISS_INCLUDE,
     '-I' + FAISS_ROOT,
 ]
-PACKAGE_DATA = ['*.i', '*.h']
 
 if sys.platform == 'win32':
     EXTRA_COMPILE_ARGS += [
@@ -76,7 +75,6 @@ if sys.platform == 'win32':
             'openblas.lib',
         ]
     SWIG_OPTS += ['-DSWIGWIN']
-    PACKAGE_DATA += ['*.dll']
 elif sys.platform == 'linux':
     EXTRA_COMPILE_ARGS += [
         '-std=c++11',
@@ -183,7 +181,7 @@ setup(
         'faiss.contrib': os.path.join(FAISS_ROOT, 'contrib'),
     },
     package_data={
-        'faiss': PACKAGE_DATA,
+        'faiss': ['*.i', '*.h'],
     },
     ext_modules=[_swigfaiss],
     cmdclass={'build_py': CustomBuildPy},

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ SWIG_OPTS = [
     '-I' + FAISS_INCLUDE,
     '-I' + FAISS_ROOT,
 ]
+PACKAGE_DATA = ['*.i', '*.h']
 
 if sys.platform == 'win32':
     EXTRA_COMPILE_ARGS += [
@@ -98,6 +99,7 @@ elif sys.platform == 'linux':
             '-lgfortran',
         ]
     SWIG_OPTS += ['-DSWIGWORDSIZE64']
+    PACKAGE_DATA += ['*.dll']
 elif sys.platform == 'darwin':
     EXTRA_COMPILE_ARGS += [
         '-std=c++11',
@@ -181,7 +183,7 @@ setup(
         'faiss.contrib': os.path.join(FAISS_ROOT, 'contrib'),
     },
     package_data={
-        'faiss': ['*.i', '*.h'],
+        'faiss': PACKAGE_DATA,
     },
     ext_modules=[_swigfaiss],
     cmdclass={'build_py': CustomBuildPy},


### PR DESCRIPTION
Use `delvewheel` to bundle missing DLLs.
The previous PR #43 had a bug in CI step uploading the incorrect wheel.

Resolve #38 #39 