### PR TITLE
Upgrade CUDA to 11.0 and support Ampere

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ faiss python wheel packages.
 This repository provides scripts to create wheel packages for the
 [faiss](https://github.com/facebookresearch/faiss) library.
 
-- Builds CPU-only or CUDA-10.0+ compatible wheels.
+- Builds CPU-only or CUDA-11.0+ compatible wheels with [cibuildwheel](https://github.com/pypa/cibuildwheel/).
 - Bundles OpenBLAS in Linux/Windows
 - Uses Accelerate framework on macOS
 - CUDA runtime and cuBLAS are statically linked

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -5,12 +5,10 @@ export CXXFLAGS="-fvisibility=hidden -fdata-sections -ffunction-sections"
 FAISS_ENABLE_GPU=${FAISS_ENABLE_GPU:-"OFF"}
 FAISS_OPT_LEVEL=${FAISS_OPT_LEVEL:-"generic"}
 
-CUDA_VERSION="10.0"
-CUDA_PKG_VERSION="10-0-10.0.130-1"
-CUBLAS_PKG_VERSION=${CUDA_PKG_VERSION}
-CURAND_PKG_VERSION=${CUDA_PKG_VERSION}
+CUDA_VERSION="11.0"
+CUDA_PKG_VERSION="11-0"
 NVIDIA_REPO_URL="http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo"
-CMAKE_CUDA_ARCHITECTURES="35-real;50-real;60-real;70-real;75"
+CMAKE_CUDA_ARCHITECTURES="35-real;50-real;60-real;70-real;75-real;80"
 
 # Fix manylinux2014 aarch64
 if [[ $(uname -m) == "aarch64" ]]; then
@@ -24,9 +22,9 @@ if [[ ${FAISS_ENABLE_GPU} == "ON" ]]; then
         yum-config-manager --add-repo ${NVIDIA_REPO_URL} && \
         yum repolist && \
         yum -y install \
-            cuda-command-line-tools-${CUDA_PKG_VERSION} \
-            cuda-cublas-dev-${CUBLAS_PKG_VERSION} \
-            cuda-curand-dev-${CURAND_PKG_VERSION} \
+            cuda-compiler-${CUDA_PKG_VERSION} \
+            libcublas-devel-${CUDA_PKG_VERSION} \
+            libcurand-devel-${CUDA_PKG_VERSION} \
             devtoolset-7-gcc \
             devtoolset-7-gcc-c++ \
             devtoolset-7-gcc-gfortran \

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -8,7 +8,7 @@ FAISS_OPT_LEVEL=${FAISS_OPT_LEVEL:-"generic"}
 CUDA_VERSION="11.0"
 CUDA_PKG_VERSION="11-0"
 NVIDIA_REPO_URL="http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo"
-CMAKE_CUDA_ARCHITECTURES="35-real;50-real;60-real;70-real;75-real;80"
+CMAKE_CUDA_ARCHITECTURES="60-real;70-real;75-real;80"
 
 # Fix manylinux2014 aarch64
 if [[ $(uname -m) == "aarch64" ]]; then

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -23,8 +23,7 @@ if [[ ${FAISS_ENABLE_GPU} == "ON" ]]; then
         yum repolist && \
         yum -y install \
             cuda-compiler-${CUDA_PKG_VERSION} \
-            libcublas-devel-${CUDA_PKG_VERSION} \
-            libcurand-devel-${CUDA_PKG_VERSION} \
+            cuda-libraries-devel-${CUDA_PKG_VERSION} \
             devtoolset-7-gcc \
             devtoolset-7-gcc-c++ \
             devtoolset-7-gcc-gfortran \

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -24,6 +24,7 @@ if [[ ${FAISS_ENABLE_GPU} == "ON" ]]; then
         yum -y install \
             cuda-compiler-${CUDA_PKG_VERSION} \
             cuda-libraries-devel-${CUDA_PKG_VERSION} \
+            cuda-nvprof-${CUDA_PKG_VERSION} \
             devtoolset-7-gcc \
             devtoolset-7-gcc-c++ \
             devtoolset-7-gcc-gfortran \

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ elif sys.platform == 'linux':
         if FAISS_ENABLE_GPU:
             EXTRA_LINK_ARGS += [
                 '-lcublas_static',
+                '-lcublasLt_static',
                 '-lcudart_static',
                 '-lculibos'
             ]


### PR DESCRIPTION
Upgrade CUDA to 11.0 to support Ampere architecture

Ref: #54 