### PR TITLE
Add install dependency on numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ setup(
     author_email='KotaYamaguchi1984@gmail.com',
     license='MIT',
     keywords='search nearest neighbors',
+    install_requires=['numpy'],
     setup_requires=['numpy'],
     packages=['faiss', 'faiss.contrib'],
     package_dir={


### PR DESCRIPTION
Add install dependency on numpy to fix failed imports of faiss if environment does not already have numpy installed.

Fixes issue #78 