### PR TITLE
Correctly add `packaging` as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = ["numpy"]
+dependencies = ["numpy", "packaging"]
 
 [project.urls]
 Repository = "https://github.com/kyamagu/faiss-wheels"

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,6 @@ setup(
         "faiss.contrib": os.path.join(FAISS_ROOT, "contrib"),
     },
     include_package_data=False,
-    install_requires=["packaging"],
     package_data={"": ["*.i", "*.h"]},
     ext_modules=ext_modules,
     cmdclass={"build_py": CustomBuildPy},

--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,7 @@ setup(
         "faiss.contrib": os.path.join(FAISS_ROOT, "contrib"),
     },
     include_package_data=False,
+    install_requires=["packaging"],
     package_data={"": ["*.i", "*.h"]},
     ext_modules=ext_modules,
     cmdclass={"build_py": CustomBuildPy},


### PR DESCRIPTION
This is a follow-up for https://github.com/facebookresearch/faiss/pull/3191.

## Issue
Importing `faiss` fails at runtime;

```python
>>> import faiss
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../site-packages/faiss/__init__.py", line 16, in <module>
    from .loader import *
  File ".../site-packages/faiss/loader.py", line 6, in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'

```
