### PR TITLE
Create /usr/local structure if not existing in macOS

### DIFF
--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -9,6 +9,12 @@ if [[ ${TARGET_ARCH} == auto* || ${TARGET_ARCH} == native ]]; then
 fi
 echo "TARGET_ARCH=${TARGET_ARCH}"
 
+# Fix directory structure
+sudo mkdir -p /usr/local/include && \
+    sudo chown -R $(whoami) /usr/local/include
+sudo mkdir -p /usr/local/lib && \
+    sudo chown -R $(whoami) /usr/local/lib
+
 # Install system dependencies
 brew install swig
 

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -14,6 +14,8 @@ sudo mkdir -p /usr/local/include && \
     sudo chown -R $(whoami) /usr/local/include
 sudo mkdir -p /usr/local/lib && \
     sudo chown -R $(whoami) /usr/local/lib
+sudo mkdir -p /usr/local/share && \
+    sudo chown -R $(whoami) /usr/local/share
 
 # Install system dependencies
 brew install swig


### PR DESCRIPTION
Changes:
- Create missing CMake install directories if not existing on macOS

https://github.com/actions/runner-images/issues/9272