### PR TITLE
Pin the macos runner version to support x86_64 arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,8 @@ jobs:
           - os: ubuntu-latest
             arch: aarch64
             opt_level: generic
-          - os: macos-latest
-            arch: auto64
+          - os: macos-13
+            arch: x86_64
             opt_level: avx2
           - os: macos-latest
             arch: arm64


### PR DESCRIPTION
Changes:
- Pin the runner image to `macos-13` to build a wheel on x86_64 environment

Fix #109 