### PR TITLE
Upgrade faiss to v1.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,8 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: >
             FAISS_OPT_LEVEL=${{ matrix.opt_level }}
             TARGET_ARCH=${{ matrix.arch }}
+            LDFLAGS="${LDFLAGS} -L/opt/homebrew/opt/libomp/lib"
+            CPPFLAGS="${CPPFLAGS} -I/opt/homebrew/opt/libomp/include"
             LIBOMP_USE_HIDDEN_HELPER_TASK=0
             LIBOMP_NUM_HIDDEN_HELPER_THREADS=0
             KMP_DUPLICATE_LIB_OK=TRUE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,8 @@ jobs:
           CIBW_BEFORE_ALL: bash scripts/build_${{ runner.os }}.sh
           CIBW_BEFORE_TEST_LINUX: pip install torch --index-url https://download.pytorch.org/whl/cpu
           CIBW_TEST_COMMAND: >
-            env -u FAISS_OPT_LEVEL pytest {project}/faiss/tests
+            env -u FAISS_OPT_LEVEL pytest {project}/faiss/tests &&
+            env -u FAISS_OPT_LEVEL pytest -s {project}/faiss/tests/torch_test*.py
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,13 @@ jobs:
         with:
           platforms: arm64
 
+      - name: Set up conda
+        if: runner.os == 'Windows'
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-activate-base: true
+          activate-environment: ""
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.21.1
 
@@ -93,9 +100,6 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: >
             FAISS_OPT_LEVEL=${{ matrix.opt_level }}
             CMAKE_PREFIX_PATH="c:\\opt"
-            PATH="${PATH};${CONDA}\\condabin;${CONDA}\\Library\\bin"
-            LIB="${LIB};${CMAKE_PREFIX_PATH}\\lib;${CONDA}\\Library\\lib"
-            CPATH="${CPATH};${CMAKE_PREFIX_PATH}\\include;${CONDA}\\Library\\include"
           CIBW_BEFORE_ALL: bash scripts/build_${{ runner.os }}.sh
           CIBW_BEFORE_TEST_LINUX: pip install torch --index-url https://download.pytorch.org/whl/cpu
           CIBW_TEST_COMMAND: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
             LIBOMP_USE_HIDDEN_HELPER_TASK=0
             LIBOMP_NUM_HIDDEN_HELPER_THREADS=0
             KMP_DUPLICATE_LIB_OK=TRUE
+            OMP_NUM_THREADS=1
             MACOSX_DEPLOYMENT_TARGET=10.14
           CIBW_ENVIRONMENT_WINDOWS: >
             FAISS_OPT_LEVEL=${{ matrix.opt_level }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,8 +106,7 @@ jobs:
           CIBW_BEFORE_ALL: bash scripts/build_${{ runner.os }}.sh
           CIBW_BEFORE_TEST_LINUX: pip install torch --index-url https://download.pytorch.org/whl/cpu
           CIBW_TEST_COMMAND: >
-            env -u FAISS_OPT_LEVEL pytest {project}/faiss/tests &&
-            env -u FAISS_OPT_LEVEL pytest -s {project}/faiss/tests/torch_test*.py
+            env -u FAISS_OPT_LEVEL pytest {project}/faiss/tests
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           - os: macos-latest
             arch: arm64
             opt_level: generic
-          - os: windows-2019
+          - os: windows-latest
             arch: auto64
             opt_level: avx2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,8 +93,6 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: >
             FAISS_OPT_LEVEL=${{ matrix.opt_level }}
             TARGET_ARCH=${{ matrix.arch }}
-            LDFLAGS="${LDFLAGS} -L/opt/homebrew/opt/libomp/lib"
-            CPPFLAGS="${CPPFLAGS} -I/opt/homebrew/opt/libomp/include"
             LIBOMP_USE_HIDDEN_HELPER_TASK=0
             LIBOMP_NUM_HIDDEN_HELPER_THREADS=0
             KMP_DUPLICATE_LIB_OK=TRUE
@@ -108,8 +106,7 @@ jobs:
           CIBW_BEFORE_ALL: bash scripts/build_${{ runner.os }}.sh
           CIBW_BEFORE_TEST_LINUX: pip install torch --index-url https://download.pytorch.org/whl/cpu
           CIBW_TEST_COMMAND: >
-            env -u FAISS_OPT_LEVEL pytest {project}/faiss/tests &&
-            env -u FAISS_OPT_LEVEL pytest -s {project}/faiss/tests/torch_test_contrib.py
+            env -u FAISS_OPT_LEVEL pytest {project}/faiss/tests
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,8 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: >
             FAISS_OPT_LEVEL=${{ matrix.opt_level }}
             CMAKE_PREFIX_PATH="c:\\opt"
+            LIB="${LIB};${CMAKE_PREFIX_PATH}\\lib;${CONDA}\\Library\\lib"
+            CPATH="${CPATH};${CMAKE_PREFIX_PATH}\\include;${CONDA}\\Library\\include"
           CIBW_BEFORE_ALL: bash scripts/build_${{ runner.os }}.sh
           CIBW_BEFORE_TEST_LINUX: pip install torch --index-url https://download.pytorch.org/whl/cpu
           CIBW_TEST_COMMAND: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,13 +68,13 @@ jobs:
           python-version: "3.x"
 
       - name: Set up QEMU
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.arch == 'aarch64'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.5
+        run: python -m pip install cibuildwheel==2.21.1
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           - os: macos-latest
             arch: arm64
             opt_level: generic
-          - os: windows-latest
+          - os: windows-2019
             arch: auto64
             opt_level: avx2
 

--- a/patch/faiss-remove-lapack.patch
+++ b/patch/faiss-remove-lapack.patch
@@ -1,16 +1,17 @@
 diff --git a/faiss/CMakeLists.txt b/faiss/CMakeLists.txt
-index 22dac7cb..e330cf36 100644
+index 2871d974..f823348c 100644
 --- a/faiss/CMakeLists.txt
 +++ b/faiss/CMakeLists.txt
-@@ -307,11 +307,6 @@ else()
-   target_link_libraries(faiss PRIVATE ${BLAS_LIBRARIES})
+@@ -365,12 +365,6 @@ else()
    target_link_libraries(faiss_avx2 PRIVATE ${BLAS_LIBRARIES})
    target_link_libraries(faiss_avx512 PRIVATE ${BLAS_LIBRARIES})
+   target_link_libraries(faiss_sve PRIVATE ${BLAS_LIBRARIES})
 -
 -  find_package(LAPACK REQUIRED)
 -  target_link_libraries(faiss PRIVATE ${LAPACK_LIBRARIES})
 -  target_link_libraries(faiss_avx2 PRIVATE ${LAPACK_LIBRARIES})
 -  target_link_libraries(faiss_avx512 PRIVATE ${LAPACK_LIBRARIES})
+-  target_link_libraries(faiss_sve PRIVATE ${LAPACK_LIBRARIES})
  endif()
  
  install(TARGETS faiss

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,10 @@ addopts = [
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestComponents::test_update_codebooks_with_double",
 ]
 testpaths = ["faiss/tests"]
+python_files = "test_*.py torch_test_*.py"
 
 [tool.cibuildwheel]
-skip = "pp* *-musllinux*"
+skip = "pp* cp313-* *-musllinux*"
 test-skip = "*-macosx_x86_64 *-manylinux_aarch64 *-win_amd64 cp312-*"
 
 test-requires = ["pytest", "scipy", "torch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ testpaths = ["faiss/tests"]
 
 [tool.cibuildwheel]
 skip = "pp* *-musllinux*"
-test-skip = "*-macosx_arm64 *-manylinux_aarch64 *-win_amd64 cp312-*"
+test-skip = "*-macosx_x86_64 *-manylinux_aarch64 *-win_amd64 cp312-*"
 
 test-requires = ["pytest", "scipy", "torch"]
 test-command = "pytest {project}/faiss/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = ["numpy>=1.0,<2.0", "packaging"]
+dependencies = ["numpy>=1.25.0,<3.0", "packaging"]
 
 [project.urls]
 Repository = "https://github.com/kyamagu/faiss-wheels"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faiss-cpu"
-version = "1.8.0.post1"
+version = "1.9.0"
 authors = [
     { name = "Kota Yamaguchi", email = "yamaguchi_kota@cyberagent.co.jp" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ addopts = [
     # Failing tests for numerical issues.
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestProductLocalSearchQuantizer::test_lut",
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestComponents::test_update_codebooks_with_double",
+    "--deselect=faiss/tests/test_contrib.py",
 ]
 testpaths = ["faiss/tests"]
 python_files = "test_*.py torch_test_*.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "A library for efficient similarity search and clustering of dense vectors."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["faiss", "similarity search", "clustering", "machine learning"]
 license = { text = "MIT License" }
 classifiers = [
@@ -25,7 +25,6 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -48,7 +47,7 @@ testpaths = ["faiss/tests"]
 python_files = "test_*.py torch_test_*.py"
 
 [tool.cibuildwheel]
-skip = "pp* cp313-* *-musllinux*"
+skip = "pp* cp38-* cp313-* *-musllinux*"
 test-skip = "*-macosx_x86_64 *-manylinux_aarch64 *-win_amd64 cp312-*"
 
 test-requires = ["pytest", "scipy", "torch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ addopts = [
     # Failing tests for numerical issues.
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestProductLocalSearchQuantizer::test_lut",
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestComponents::test_update_codebooks_with_double",
-    "--deselect=faiss/tests/test_contrib.py",
 ]
 testpaths = ["faiss/tests"]
 python_files = "test_*.py"  # torch_test_*.py will break the other tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ addopts = [
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestProductLocalSearchQuantizer::test_lut",
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestComponents::test_update_codebooks_with_double",
     "--deselect=faiss/tests/test_contrib.py::TestPreassigned::test_float",
+    "--deselect=faiss/tests/test_contrib.py::TestClustering::test_ivf_train_2level",
 ]
 testpaths = ["faiss/tests"]
 python_files = "test_*.py"  # torch_test_*.py will break the other tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ addopts = [
     # Failing tests for numerical issues.
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestProductLocalSearchQuantizer::test_lut",
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestComponents::test_update_codebooks_with_double",
+    "--deselect=faiss/tests/test_contrib.py::TestPreassigned::test_float",
 ]
 testpaths = ["faiss/tests"]
 python_files = "test_*.py"  # torch_test_*.py will break the other tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy>=1.25.0,<2",
+    "numpy>=2.0,<3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -31,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = ["numpy>=1.25.0,<2.0", "packaging"]
+dependencies = ["numpy>=1.25.0,<3.0", "packaging"]
 
 [project.urls]
 Repository = "https://github.com/kyamagu/faiss-wheels"
@@ -45,7 +45,7 @@ addopts = [
     "--deselect=faiss/tests/test_contrib.py",
 ]
 testpaths = ["faiss/tests"]
-python_files = "test_*.py torch_test_*.py"
+python_files = "test_*.py"  # torch_test_*.py will break the other tests
 
 [tool.cibuildwheel]
 skip = "pp* cp38-* cp313-* *-musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy>=2.0,<3",
+    "numpy>=1.25.0,<2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -31,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = ["numpy>=1.25.0,<3.0", "packaging"]
+dependencies = ["numpy>=1.25.0,<2.0", "packaging"]
 
 [project.urls]
 Repository = "https://github.com/kyamagu/faiss-wheels"
@@ -48,7 +48,7 @@ python_files = "test_*.py torch_test_*.py"
 
 [tool.cibuildwheel]
 skip = "pp* cp38-* cp313-* *-musllinux*"
-test-skip = "*-macosx_x86_64 *-manylinux_aarch64 *-win_amd64 cp312-*"
+test-skip = "*-manylinux_aarch64 *-win_amd64"
 
 test-requires = ["pytest", "scipy", "torch"]
 test-command = "pytest {project}/faiss/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "oldest-supported-numpy",
+    "numpy>=2.0,<3",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ minversion = "6.0"
 addopts = [
     # Failing tests for numerical issues.
     "--deselect=faiss/tests/test_local_search_quantizer.py::TestProductLocalSearchQuantizer::test_lut",
+    "--deselect=faiss/tests/test_local_search_quantizer.py::TestComponents::test_update_codebooks_with_double",
 ]
 testpaths = ["faiss/tests"]
 

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -40,8 +40,14 @@ if [[ ${FAISS_ENABLE_GPU} == "ON" ]]; then
     export CUDAFLAGS="--compiler-options=${CXXFLAGS// /,}"
 fi
 
+# Check if swig is available
+if ! command -v swig &> /dev/null; then
+    echo "swig is not available. Please install swig."
+    exit 1
+fi
+
 # Install system dependencies
-yum install -y openblas-devel openblas-static swig3
+yum install -y openblas-devel openblas-static
 
 # Build and patch faiss
 cd faiss && \

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -45,6 +45,7 @@ if ! command -v swig &> /dev/null; then
     echo "swig is not available. Please install swig."
     exit 1
 fi
+swig -version
 
 # Install system dependencies
 yum install -y openblas-devel openblas-static

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -5,7 +5,7 @@ set -eux
 CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-"c:\\opt"}
 
 # Install system dependencies
-conda.bat install -c conda-forge openblas
+conda.bat install -y -c conda-forge openblas
 
 # Build and patch faiss
 cd faiss && \

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -4,6 +4,9 @@ set -eux
 
 CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-"c:\\opt"}
 
+# Show env
+env
+
 # Install system dependencies
 conda.bat install -y -c conda-forge openblas
 

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -8,7 +8,7 @@ CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-"c:\\opt"}
 env
 
 # Install system dependencies
-conda.bat install -y -c conda-forge openblas
+conda install -y -c conda-forge openblas
 
 # Build and patch faiss
 cd faiss && \

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -18,28 +18,30 @@ sudo mkdir -p /usr/local/share && \
     sudo chown -R $(whoami) /usr/local/share
 
 # Install system dependencies
-brew install swig
+brew install swig libomp
 
 # Build libomp: needed for cross compilation
-echo "Building libomp"
-git clone \
-        --depth 1 \
-        --filter=blob:none \
-        --sparse \
-        --branch ${LLVM_VERSION:-"llvmorg-17.0.6"} \
-        https://github.com/llvm/llvm-project.git \
-        third-party/llvm-project && \
-    cd third-party/llvm-project && \
-    git sparse-checkout set openmp cmake && \
-    cd openmp && \
-    cmake . \
-        -B build \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_OSX_ARCHITECTURES=${TARGET_ARCH} \
-        -DLIBOMP_ENABLE_SHARED=ON && \
-    cmake --build build -j && \
-    cmake --install build && \
-    cd ../../..
+function build_libomp() {
+    echo "Building libomp"
+    git clone \
+            --depth 1 \
+            --filter=blob:none \
+            --sparse \
+            --branch ${LLVM_VERSION:-"llvmorg-17.0.6"} \
+            https://github.com/llvm/llvm-project.git \
+            third-party/llvm-project && \
+        cd third-party/llvm-project && \
+        git sparse-checkout set openmp cmake && \
+        cd openmp && \
+        cmake . \
+            -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_ARCHITECTURES=${TARGET_ARCH} \
+            -DLIBOMP_ENABLE_SHARED=ON && \
+        cmake --build build -j && \
+        cmake --install build && \
+        cd ../../..
+}
 
 # Build and patch faiss
 echo "Building faiss"

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -18,7 +18,7 @@ sudo mkdir -p /usr/local/share && \
     sudo chown -R $(whoami) /usr/local/share
 
 # Install system dependencies
-brew install swig libomp
+brew install swig
 
 # Build libomp: needed for cross compilation
 function build_libomp() {
@@ -27,7 +27,7 @@ function build_libomp() {
             --depth 1 \
             --filter=blob:none \
             --sparse \
-            --branch ${LLVM_VERSION:-"llvmorg-17.0.6"} \
+            --branch ${LLVM_VERSION:-"llvmorg-19.1.1"} \
             https://github.com/llvm/llvm-project.git \
             third-party/llvm-project && \
         cd third-party/llvm-project && \
@@ -42,6 +42,8 @@ function build_libomp() {
         cmake --install build && \
         cd ../../..
 }
+
+build_libomp()
 
 # Build and patch faiss
 echo "Building faiss"

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -43,7 +43,7 @@ function build_libomp() {
         cd ../../..
 }
 
-build_libomp()
+build_libomp
 
 # Build and patch faiss
 echo "Building faiss"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ FAISS_ENABLE_GPU = (os.getenv("FAISS_ENABLE_GPU", "").lower() in ("on", "true"))
 # Common configurations
 FAISS_ROOT = "faiss"  # relative to the setup.py file
 
-DEFINE_MACROS = [("FINTEGER", "int")]
+# DEFINE_MACROS = [("FINTEGER", "int")]
 INCLUDE_DIRS = [
     np.get_include(), FAISS_ROOT, os.path.join(FAISS_INSTALL_PREFIX, "include")]
 LIBRARY_DIRS: List[str] = [os.path.join(FAISS_INSTALL_PREFIX, "lib")]

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ FAISS_ENABLE_GPU = (os.getenv("FAISS_ENABLE_GPU", "").lower() in ("on", "true"))
 FAISS_ROOT = "faiss"  # relative to the setup.py file
 
 # DEFINE_MACROS = [("FINTEGER", "int")]
+DEFINE_MACROS = []
 INCLUDE_DIRS = [
     np.get_include(), FAISS_ROOT, os.path.join(FAISS_INSTALL_PREFIX, "include")]
 LIBRARY_DIRS: List[str] = [os.path.join(FAISS_INSTALL_PREFIX, "lib")]

--- a/setup.py
+++ b/setup.py
@@ -9,20 +9,23 @@ from setuptools.command.build_py import build_py
 # Faiss conifgurations
 FAISS_INSTALL_PREFIX = os.getenv("FAISS_INSTALL_PREFIX", "/usr/local")
 FAISS_OPT_LEVEL = os.getenv("FAISS_OPT_LEVEL", "generic")
-FAISS_ENABLE_GPU = (os.getenv("FAISS_ENABLE_GPU", "").lower() in ("on", "true"))
+FAISS_ENABLE_GPU = os.getenv("FAISS_ENABLE_GPU", "").lower() in ("on", "true")
 
 # Common configurations
 FAISS_ROOT = "faiss"  # relative to the setup.py file
 
-# DEFINE_MACROS = [("FINTEGER", "int")]
 DEFINE_MACROS = []
 INCLUDE_DIRS = [
-    np.get_include(), FAISS_ROOT, os.path.join(FAISS_INSTALL_PREFIX, "include")]
+    np.get_include(),
+    FAISS_ROOT,
+    os.path.join(FAISS_INSTALL_PREFIX, "include"),
+]
 LIBRARY_DIRS: List[str] = [os.path.join(FAISS_INSTALL_PREFIX, "lib")]
 EXTRA_COMPILE_ARGS: List[str] = []
 EXTRA_LINK_ARGS: List[str] = []
 SWIG_OPTS = ["-c++", "-Doverride=", "-doxygen", f"-I{FAISS_ROOT}"] + [
-    f"-I{x}" for x in INCLUDE_DIRS]
+    f"-I{x}" for x in INCLUDE_DIRS
+]
 
 # GPU options
 if FAISS_ENABLE_GPU:
@@ -40,15 +43,16 @@ def win32_options(
 ) -> dict:
     """Windows options."""
     return dict(
-        extra_compile_args=extra_compile_args + [
+        extra_compile_args=extra_compile_args
+        + [
             "/openmp:llvm",
             "/std:c++17",
             "/Zc:inline",
             "/wd4101",  # unreferenced local variable.
             "/MD",  # Bugfix: https://bugs.python.org/issue38597
         ],
-        extra_link_args=["/OPT:ICF", "/OPT:REF"] + (
-            extra_link_args or ["faiss.lib", "openblas.lib"]),
+        extra_link_args=["/OPT:ICF", "/OPT:REF"]
+        + (extra_link_args or ["faiss.lib", "openblas.lib"]),
         swig_opts=swig_opts + ["-DSWIGWIN"],
     )
 
@@ -72,7 +76,8 @@ def linux_options(
             "-lculibos",
         ]
     return dict(
-        extra_compile_args=extra_compile_args + [
+        extra_compile_args=extra_compile_args
+        + [
             "-std=c++17",
             "-Wno-sign-compare",
             "-fopenmp",
@@ -84,8 +89,13 @@ def linux_options(
             "-lrt",
             "-s",
             "-Wl,--gc-sections",
-        ] + (extra_link_args or default_link_args),
-        swig_opts=swig_opts,
+        ]
+        + (extra_link_args or default_link_args),
+        swig_opts=swig_opts
+        + [
+            ("SWIGTYPE_p_unsigned_long", "SWIGTYPE_p_unsigned_int"),
+            ("SWIGTYPE_p_long", "SWIGTYPE_p_int"),
+        ],
     )
 
 
@@ -96,7 +106,8 @@ def darwin_options(
 ) -> dict:
     """macOS options."""
     return dict(
-        extra_compile_args=extra_compile_args + [
+        extra_compile_args=extra_compile_args
+        + [
             "-std=c++17",
             "-Wno-sign-compare",
             "-Xpreprocessor",
@@ -106,12 +117,16 @@ def darwin_options(
             "-Xpreprocessor",
             "-fopenmp",
             "-dead_strip",
-        ] + (extra_link_args or [
-            "-lfaiss",
-            "-lomp",
-            "-framework",
-            "Accelerate",
-        ]),
+        ]
+        + (
+            extra_link_args
+            or [
+                "-lfaiss",
+                "-lomp",
+                "-framework",
+                "Accelerate",
+            ]
+        ),
         swig_opts=swig_opts,
     )
 
@@ -166,8 +181,15 @@ def avx512_options(
         flags = ["/arch:AVX512", "/bigobj"]
     else:
         flags = [
-            "-mavx2", "-mfma", "-mf16c", "-mavx512f", "-mavx512cd", "-mavx512vl",
-            "-mavx512dq", "-mavx512bw", "-mpopcnt"
+            "-mavx2",
+            "-mfma",
+            "-mf16c",
+            "-mavx512f",
+            "-mavx512cd",
+            "-mavx512vl",
+            "-mavx512dq",
+            "-mavx512bw",
+            "-mpopcnt",
         ]
     return dict(
         name="faiss._swigfaiss_avx512",
@@ -184,7 +206,8 @@ OPT_CONFIGS = {
 }
 
 platform_config = PLATFORM_CONFIGS[sys.platform](
-    EXTRA_COMPILE_ARGS, EXTRA_LINK_ARGS, SWIG_OPTS)
+    EXTRA_COMPILE_ARGS, EXTRA_LINK_ARGS, SWIG_OPTS
+)
 
 ext_modules = [
     Extension(
@@ -205,6 +228,7 @@ ext_modules = [
 
 class CustomBuildPy(build_py):
     """Run build_ext before build_py to compile swig code."""
+
     def run(self):
         self.run_command("build_ext")
         return build_py.run(self)

--- a/setup.py
+++ b/setup.py
@@ -91,11 +91,7 @@ def linux_options(
             "-Wl,--gc-sections",
         ]
         + (extra_link_args or default_link_args),
-        swig_opts=swig_opts
-        + [
-            ("SWIGTYPE_p_unsigned_long", "SWIGTYPE_p_unsigned_int"),
-            ("SWIGTYPE_p_long", "SWIGTYPE_p_int"),
-        ],
+        swig_opts=swig_opts + ["-DSWIGWORDSIZE64"],
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -235,6 +235,7 @@ setup(
     package_dir={
         "faiss": os.path.join(FAISS_ROOT, "faiss", "python"),
         "faiss.contrib": os.path.join(FAISS_ROOT, "contrib"),
+        "faiss.contrib.torch": os.path.join(FAISS_ROOT, "contrib", "torch"),
     },
     include_package_data=False,
     package_data={"": ["*.i", "*.h"]},

--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,7 @@ class CustomBuildPy(build_py):
 
 
 setup(
-    packages=["faiss", "faiss.contrib"],
+    packages=["faiss", "faiss.contrib", "faiss.contrib.torch"],
     package_dir={
         "faiss": os.path.join(FAISS_ROOT, "faiss", "python"),
         "faiss.contrib": os.path.join(FAISS_ROOT, "contrib"),

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ def linux_options(
             "-s",
             "-Wl,--gc-sections",
         ] + (extra_link_args or default_link_args),
-        swig_opts=swig_opts + ["-DSWIGWORDSIZE64"],
+        swig_opts=swig_opts,
     )
 
 


### PR DESCRIPTION
Changes:
- Upgrade bundled faiss to [v1.9.0](https://github.com/facebookresearch/faiss/releases/tag/v1.9.0)
- Drop cp38 support
- Support NumPy 2
- Fix centos EOL issue in manylinux container
- Use `setup-miniconda` in windows
- Disable unstable tests