### PR TITLE
Add /usr/lib as a link directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ def linux_options(
         "-l:libfaiss.a",
         "-l:libopenblas.a",
         "-lgfortran",
+        "-L/usr/lib",
     ]
     if FAISS_ENABLE_GPU:
         default_link_args += [


### PR DESCRIPTION
Hi,

On Arch Linux, libblas.so is installed to /usr/lib. Source: https://archlinux.org/packages/extra/x86_64/blas-openblas/ > Package Contents

This fixes that.