### PR TITLE
Fix CMake unable to detect OpenMP in Windows runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faiss-cpu"
-version = "1.9.0"
+version = "1.9.0.post1"
 authors = [
     { name = "Kota Yamaguchi", email = "yamaguchi_kota@cyberagent.co.jp" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faiss-cpu"
-version = "1.9.0.post1"
+version = "1.9.0"
 authors = [
     { name = "Kota Yamaguchi", email = "yamaguchi_kota@cyberagent.co.jp" },
 ]

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -8,7 +8,7 @@ CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-"c:\\opt"}
 env
 
 # Install system dependencies
-conda install -y -c conda-forge openblas "cmake<3.30.0"
+conda install -y -c conda-forge openblas libflang openmp
 
 # Build and patch faiss
 cd faiss && \

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -23,7 +23,8 @@ cd faiss && \
         -DBUILD_TESTING=OFF \
         -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
         -DCMAKE_BUILD_TYPE=Release \
-        -DBLA_STATIC=ON && \
+        -DBLA_STATIC=ON \
+        -DOpenMP_RUNTIME_MSVC="llvm" && \
     cmake --build build --config Release -j && \
     cmake --install build --prefix "${CMAKE_PREFIX_PATH}" && \
     git apply ../patch/faiss-rename-swigfaiss.patch && \

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -8,7 +8,7 @@ CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-"c:\\opt"}
 env
 
 # Install system dependencies
-conda install -y -c conda-forge openblas
+conda install -y -c conda-forge openblas cmake
 
 # Build and patch faiss
 cd faiss && \
@@ -23,8 +23,7 @@ cd faiss && \
         -DBUILD_TESTING=OFF \
         -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
         -DCMAKE_BUILD_TYPE=Release \
-        -DBLA_STATIC=ON \
-        -DOpenMP_RUNTIME_MSVC="llvm" && \
+        -DBLA_STATIC=ON && \
     cmake --build build --config Release -j && \
     cmake --install build --prefix "${CMAKE_PREFIX_PATH}" && \
     git apply ../patch/faiss-rename-swigfaiss.patch && \

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -4,9 +4,6 @@ set -eux
 
 CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-"c:\\opt"}
 
-# Show env
-env
-
 # Install system dependencies
 conda install -y -c conda-forge openblas libflang openmp
 

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -8,7 +8,7 @@ CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-"c:\\opt"}
 env
 
 # Install system dependencies
-conda install -y -c conda-forge openblas cmake
+conda install -y -c conda-forge openblas "cmake<3.30.0"
 
 # Build and patch faiss
 cd faiss && \


### PR DESCRIPTION
Changes:
- Fix windows build error due to CMake unable to detect OpenMP