### PR TITLE
Add Dependabot configuration for CI toolchain updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable automated dependency updates
- Tracks **GitHub Actions** (all actions in `build.yml`) with weekly updates, grouped into a single PR to reduce noise
- Tracks **pip dependencies** from `pyproject.toml` with weekly updates
- Both scheduled for Mondays

## Notes

- `pypa/gh-action-pypi-publish@release/v1` is pinned to a branch ref — Dependabot cannot update branch-pinned actions, so this will need occasional manual attention
- Git submodules (`faiss`, `OpenBLAS`) are intentionally excluded as they are project-version pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)